### PR TITLE
Fix: Edit message EditText is not clickable

### DIFF
--- a/app/src/main/java/com/synapse/social/studioasinc/ChatActivity.java
+++ b/app/src/main/java/com/synapse/social/studioasinc/ChatActivity.java
@@ -38,6 +38,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowManager;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -910,7 +911,14 @@ public class ChatActivity extends AppCompatActivity {
 				msgRef2.child(MESSAGE_TEXT_KEY).setValue(newText);
 			});
 			dialog.setNegativeButton("Cancel", null);
-			dialog.show();
+			AlertDialog shownDialog = dialog.show();
+
+			// Request focus and show keyboard
+			editText.requestFocus();
+			if (shownDialog.getWindow() != null) {
+				shownDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+			}
+
 			popupWindow.dismiss();
 		});
 		

--- a/app/src/main/java/com/synapse/social/studioasinc/ChatActivity.java
+++ b/app/src/main/java/com/synapse/social/studioasinc/ChatActivity.java
@@ -2,7 +2,7 @@ package com.synapse.social.studioasinc;
 
 import android.Manifest;
 import android.app.Activity;
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.ClipData;
 import android.content.ClipboardManager;

--- a/app/src/main/res/layout/single_et.xml
+++ b/app/src/main/res/layout/single_et.xml
@@ -20,7 +20,6 @@
 		app:boxCornerRadiusBottomEnd="18dp">
 		<EditText
 			android:id="@+id/edittext1"
-			android:focusable="false"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:padding="15dp"


### PR DESCRIPTION
The EditText in the 'edit message' dialog was not clickable and did not show the keyboard. This was caused by two issues:
1. The 'android:focusable' attribute was set to 'false' in the XML layout, preventing the EditText from being focused.
2. The soft keyboard was not being programmatically shown when the dialog appeared.

This commit addresses both issues:
- Removes `android:focusable="false"` from the EditText in `app/src/main/res/layout/single_et.xml`.
- Adds code to `app/src/main/java/com/synapse/social/studioasinc/ChatActivity.java` to request focus on the EditText and set the window's soft input mode to ensure the keyboard is displayed when the dialog is shown.
- Fixes a compilation error by changing the `android.app.AlertDialog` import to `androidx.appcompat.app.AlertDialog`.