### PR TITLE
Remove redundant attachments and improve adapter type safety

### DIFF
--- a/app/src/main/java/com/synapse/social/studioasinc/ChatAdapter.java
+++ b/app/src/main/java/com/synapse/social/studioasinc/ChatAdapter.java
@@ -519,9 +519,10 @@ public class ChatAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                 CarouselItemDecoration.createWithStandardSpacing(holder.mediaCarouselRecyclerView));
         }
         
-        // Create adapter with click listener to open gallery
-        MessageImageCarouselAdapter adapter = new MessageImageCarouselAdapter(_context, attachments, 
-            (position, attachmentList) -> openImageGallery(attachmentList, position));
+        // Convert to typed attachments once and create adapter with click listener to open gallery
+        ArrayList<Attachment> typedAttachments = AttachmentUtils.fromHashMapList(attachments);
+        MessageImageCarouselAdapter adapter = new MessageImageCarouselAdapter(_context, typedAttachments, 
+            (position, attachmentList) -> openImageGalleryTyped(attachmentList, position));
         holder.mediaCarouselRecyclerView.setAdapter(adapter);
         
         // Setup "View All" button - shows when there are more than 3 images
@@ -530,7 +531,7 @@ public class ChatAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             if (attachments.size() > 3) {
                 holder.viewAllImagesButton.setVisibility(View.VISIBLE);
                 holder.viewAllImagesButton.setText("View all " + attachments.size() + " images");
-                holder.viewAllImagesButton.setOnClickListener(v -> openImageGallery(attachments, 0));
+                holder.viewAllImagesButton.setOnClickListener(v -> openImageGalleryTyped(typedAttachments, 0));
             } else {
                 holder.viewAllImagesButton.setVisibility(View.GONE);
             }
@@ -661,13 +662,23 @@ public class ChatAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             ArrayList<Attachment> parcelableAttachments = AttachmentUtils.fromHashMapList(attachments);
             intent.putParcelableArrayListExtra("attachments_parcelable", parcelableAttachments);
             
-            // Keep legacy format for backward compatibility
-            intent.putExtra("attachments", attachments);
             intent.putExtra("position", position);
             
             _context.startActivity(intent);
             
             // Add smooth transition animations
+            if (_context instanceof Activity) {
+                ((Activity) _context).overridePendingTransition(R.anim.slide_in_from_right, R.anim.slide_out_to_left);
+            }
+        }
+    }
+
+    private void openImageGalleryTyped(ArrayList<Attachment> attachments, int position) {
+        if (_context != null && chatActivity != null) {
+            Intent intent = new Intent(_context, ImageGalleryActivity.class);
+            intent.putParcelableArrayListExtra("attachments_parcelable", attachments);
+            intent.putExtra("position", position);
+            _context.startActivity(intent);
             if (_context instanceof Activity) {
                 ((Activity) _context).overridePendingTransition(R.anim.slide_in_from_right, R.anim.slide_out_to_left);
             }

--- a/app/src/main/java/com/synapse/social/studioasinc/MessageImageCarouselAdapter.java
+++ b/app/src/main/java/com/synapse/social/studioasinc/MessageImageCarouselAdapter.java
@@ -29,22 +29,21 @@ import com.synapse.social.studioasinc.model.Attachment;
 import com.synapse.social.studioasinc.util.UIUtils;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 
 public class MessageImageCarouselAdapter extends RecyclerView.Adapter<MessageImageCarouselAdapter.ImageCarouselViewHolder> {
     
     private static final String TAG = "MessageImageCarouselAdapter";
     
     private final Context context;
-    private final ArrayList<HashMap<String, Object>> attachments;
+    private final ArrayList<Attachment> attachments;
     private final OnImageClickListener onImageClickListener;
     private final int imageSize;
     
     public interface OnImageClickListener {
-        void onImageClick(int position, ArrayList<HashMap<String, Object>> attachments);
+        void onImageClick(int position, ArrayList<Attachment> attachments);
     }
     
-    public MessageImageCarouselAdapter(Context context, ArrayList<HashMap<String, Object>> attachments, OnImageClickListener listener) {
+    public MessageImageCarouselAdapter(Context context, ArrayList<Attachment> attachments, OnImageClickListener listener) {
         this.context = context;
         this.attachments = attachments;
         this.onImageClickListener = listener;
@@ -60,8 +59,8 @@ public class MessageImageCarouselAdapter extends RecyclerView.Adapter<MessageIma
     
     @Override
     public void onBindViewHolder(@NonNull ImageCarouselViewHolder holder, int position) {
-        HashMap<String, Object> attachment = attachments.get(position);
-        String publicId = (String) attachment.get("publicId");
+        Attachment attachment = attachments.get(position);
+        String publicId = attachment.getPublicId();
         
         // Set consistent size for all carousel images
         ViewGroup.LayoutParams layoutParams = holder.cardView.getLayoutParams();


### PR DESCRIPTION
Remove redundant Serializable attachment extra and refactor `MessageImageCarouselAdapter` to use type-safe `ArrayList<Attachment>` to prevent `TransactionTooLargeException` and improve maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d569774-91e0-4562-9059-0d1c6af4cdc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d569774-91e0-4562-9059-0d1c6af4cdc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

