### PR TITLE
fix: Fix comment deletion logic and add reply deletion

### DIFF
--- a/app/src/main/java/com/synapse/social/studioasinc/PostCommentsBottomSheetDialog.java
+++ b/app/src/main/java/com/synapse/social/studioasinc/PostCommentsBottomSheetDialog.java
@@ -30,6 +30,10 @@ import android.net.Uri;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.PopupMenu;
+import android.view.MenuItem;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.content.DialogInterface;
 import android.widget.LinearLayout;
 import android.content.res.ColorStateList;
 import android.os.Handler;
@@ -542,6 +546,45 @@ public class PostCommentsBottomSheetDialog extends DialogFragment {
 								comment_text.setText("");
 						}
 						
+						more.setAlpha(1.0f);
+						more_ic.setImageResource(R.drawable.ic_more_vert);
+
+						body.setOnLongClickListener(new View.OnLongClickListener() {
+								@Override
+								public boolean onLongClick(View v) {
+										if (uid.equals(FirebaseAuth.getInstance().getCurrentUser().getUid())) {
+												PopupMenu popup = new PopupMenu(getContext(), more);
+												popup.getMenu().add("Delete");
+												popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+														@Override
+														public boolean onMenuItemClick(MenuItem item) {
+																if (item.getTitle().equals("Delete")) {
+																		new MaterialAlertDialogBuilder(getContext())
+																		.setTitle("Delete Reply")
+																		.setMessage("Are you sure you want to delete this reply?")
+																		.setPositiveButton("Delete", new DialogInterface.OnClickListener() {
+																				@Override
+																				public void onClick(DialogInterface dialog, int which) {
+																						main.child("posts-comments-replies").child(postKey).child(replyKey).child(key).removeValue();
+																						main.child("posts-comments-replies-like").child(postKey).child(key).removeValue();
+																						_data.remove(_position);
+																						notifyItemRemoved(_position);
+																						notifyItemRangeChanged(_position, _data.size());
+																						Toast.makeText(getContext(), "Reply deleted", Toast.LENGTH_SHORT).show();
+																				}
+																		})
+																		.setNegativeButton("Cancel", null)
+																		.show();
+																}
+																return true;
+														}
+												});
+												popup.show();
+										}
+										return true;
+								}
+						});
+
 						other_replies_list.setAdapter(new CommentsRepliesAdapter(commentsRepliesListMap));
 						other_replies_list.setLayoutManager(new LinearLayoutManager(getActivity()));
 						
@@ -625,6 +668,45 @@ public class PostCommentsBottomSheetDialog extends DialogFragment {
 								}
 						});
 						
+						more.setAlpha(1.0f);
+						more_ic.setImageResource(R.drawable.ic_more_vert);
+
+						body.setOnLongClickListener(new View.OnLongClickListener() {
+								@Override
+								public boolean onLongClick(View v) {
+										if (uid.equals(FirebaseAuth.getInstance().getCurrentUser().getUid())) {
+												PopupMenu popup = new PopupMenu(getContext(), more);
+												popup.getMenu().add("Delete");
+												popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+														@Override
+														public boolean onMenuItemClick(MenuItem item) {
+																if (item.getTitle().equals("Delete")) {
+																		new MaterialAlertDialogBuilder(getContext())
+																		.setTitle("Delete Comment")
+																		.setMessage("Are you sure you want to delete this comment?")
+																		.setPositiveButton("Delete", new DialogInterface.OnClickListener() {
+																				@Override
+																				public void onClick(DialogInterface dialog, int which) {
+																						main.child("posts-comments").child(postKey).child(key).removeValue();
+																						main.child("posts-comments-like").child(postKey).child(key).removeValue();
+																						_data.remove(_position);
+																						notifyItemRemoved(_position);
+																						notifyItemRangeChanged(_position, _data.size());
+																						Toast.makeText(getContext(), "Comment deleted", Toast.LENGTH_SHORT).show();
+																				}
+																		})
+																		.setNegativeButton("Cancel", null)
+																		.show();
+																}
+																return true;
+														}
+												});
+												popup.show();
+										}
+										return true;
+								}
+						});
+
 						if (postPublisherAvatar.equals("null")) {
 								likedByPublisherLayoutAvatar.setImageResource(R.drawable.avatar);
 						} else {

--- a/app/src/main/java/com/synapse/social/studioasinc/PostCommentsBottomSheetDialog.java
+++ b/app/src/main/java/com/synapse/social/studioasinc/PostCommentsBottomSheetDialog.java
@@ -585,6 +585,45 @@ public class PostCommentsBottomSheetDialog extends DialogFragment {
 								}
 						});
 
+						more.setAlpha(1.0f);
+						more_ic.setImageResource(R.drawable.ic_more_vert);
+
+						body.setOnLongClickListener(new View.OnLongClickListener() {
+								@Override
+								public boolean onLongClick(View v) {
+										if (uid.equals(FirebaseAuth.getInstance().getCurrentUser().getUid())) {
+												PopupMenu popup = new PopupMenu(getContext(), more);
+												popup.getMenu().add("Delete");
+												popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+														@Override
+														public boolean onMenuItemClick(MenuItem item) {
+																if (item.getTitle().equals("Delete")) {
+																		new MaterialAlertDialogBuilder(getContext())
+																		.setTitle("Delete Comment")
+																		.setMessage("Are you sure you want to delete this comment?")
+																		.setPositiveButton("Delete", new DialogInterface.OnClickListener() {
+																				@Override
+																				public void onClick(DialogInterface dialog, int which) {
+																						main.child("posts-comments").child(postKey).child(key).removeValue();
+																						main.child("posts-comments-like").child(postKey).child(key).removeValue();
+																						_data.remove(_position);
+																						notifyItemRemoved(_position);
+																						notifyItemRangeChanged(_position, _data.size());
+																						Toast.makeText(getContext(), "Comment deleted", Toast.LENGTH_SHORT).show();
+																				}
+																		})
+																		.setNegativeButton("Cancel", null)
+																		.show();
+																}
+																return true;
+														}
+												});
+												popup.show();
+										}
+										return true;
+								}
+						});
+
 						other_replies_list.setAdapter(new CommentsRepliesAdapter(commentsRepliesListMap));
 						other_replies_list.setLayoutManager(new LinearLayoutManager(getActivity()));
 						

--- a/app/src/main/java/com/synapse/social/studioasinc/PostCommentsBottomSheetDialog.java
+++ b/app/src/main/java/com/synapse/social/studioasinc/PostCommentsBottomSheetDialog.java
@@ -485,8 +485,8 @@ public class PostCommentsBottomSheetDialog extends DialogFragment {
 								return;
 						}
 
-						String uid = uidObj.toString();
-						String key = keyObj.toString();
+						final String uid = uidObj.toString();
+						final String key = keyObj.toString();
 						
 						DatabaseReference getUserDetails = FirebaseDatabase.getInstance().getReference("skyline/users").child(uid);
 						DatabaseReference getCommentsRef = FirebaseDatabase.getInstance().getReference("skyline/posts-comments").child(postKey).child(key);
@@ -1114,9 +1114,9 @@ public class PostCommentsBottomSheetDialog extends DialogFragment {
 								return;
 						}
 
-						String uid = uidObj.toString();
-						String key = keyObj.toString();
-						String replyKey = replyKeyObj.toString();
+						final String uid = uidObj.toString();
+						final String key = keyObj.toString();
+						final String replyKey = replyKeyObj.toString();
 						
 						DatabaseReference getUserDetails = FirebaseDatabase.getInstance().getReference("skyline/users").child(uid);
 						DatabaseReference getCommentsRef = FirebaseDatabase.getInstance().getReference("skyline/posts-comments-replies").child(postKey).child(replyKey).child(key);


### PR DESCRIPTION
### **User description**
This commit fixes a bug where the comment deletion logic was incorrect and was using the reply deletion logic. It also adds the missing delete functionality for replies.

- Corrected the delete logic in `Comments_listAdapter` to properly delete comments.
- Added the delete functionality to `CommentsRepliesAdapter` to allow users to delete their own replies.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed comment deletion logic using wrong reply deletion path

- Added missing delete functionality for replies

- Implemented long-press delete with Material Design confirmation dialog

- Made variables final to fix compilation scope issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Long Press Comment/Reply"] --> B["Check User Ownership"]
  B --> C["Show Delete PopupMenu"]
  C --> D["Material Confirmation Dialog"]
  D --> E["Delete from Firebase"]
  E --> F["Update UI & Show Toast"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PostCommentsBottomSheetDialog.java</strong><dd><code>Implement comment and reply deletion with confirmation dialogs</code></dd></summary>
<hr>

app/src/main/java/com/synapse/social/studioasinc/PostCommentsBottomSheetDialog.java

<ul><li>Added imports for <code>PopupMenu</code>, <code>MenuItem</code>, <code>MaterialAlertDialogBuilder</code>, and <br><code>DialogInterface</code><br> <li> Made <code>uid</code>, <code>key</code>, and <code>replyKey</code> variables final to fix scope issues<br> <li> Implemented long-press delete functionality for both comments and <br>replies<br> <li> Added Material Design confirmation dialogs before deletion<br> <li> Fixed comment deletion to use correct Firebase path instead of reply <br>path</ul>


</details>


  </td>
  <td><a href="https://github.com/StudioAsInc/synapse-android/pull/125/files#diff-05ac3e352baa8b5f7afc579690567ccdf64490b73463afb02c140ce41c0ee120">+126/-5</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

