### PR TITLE
Fix: Make HomeActivity shimmer placeholder visible

### DIFF
--- a/app/src/main/res/drawable/rounded_corner_placeholder_solid.xml
+++ b/app/src/main/res/drawable/rounded_corner_placeholder_solid.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#E0E0E0" />
+    <corners android:radius="8dp" />
+</shape>

--- a/app/src/main/res/layout/post_placeholder_layout.xml
+++ b/app/src/main/res/layout/post_placeholder_layout.xml
@@ -4,7 +4,10 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     app:shimmer_auto_start="true"
-    app:shimmer_color="#BDBDBD">
+    app:shimmer_base_alpha="1"
+    app:shimmer_base_color="#E0E0E0"
+    app:shimmer_highlight_alpha="0.5"
+    app:shimmer_highlight_color="#BDBDBD">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/post_placeholder_layout.xml
+++ b/app/src/main/res/layout/post_placeholder_layout.xml
@@ -4,10 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     app:shimmer_auto_start="true"
-    app:shimmer_base_alpha="1"
-    app:shimmer_base_color="#E0E0E0"
-    app:shimmer_highlight_alpha="0.5"
-    app:shimmer_highlight_color="#BDBDBD">
+    app:shimmer_color="#BDBDBD">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -24,7 +21,7 @@
             <View
                 android:layout_width="40dp"
                 android:layout_height="40dp"
-                android:background="@drawable/rounded_corner_placeholder" />
+                android:background="@drawable/rounded_corner_placeholder_solid" />
 
             <LinearLayout
                 android:layout_width="0dp"
@@ -36,13 +33,13 @@
                 <View
                     android:layout_width="120dp"
                     android:layout_height="16dp"
-                    android:background="@drawable/rounded_corner_placeholder" />
+                    android:background="@drawable/rounded_corner_placeholder_solid" />
 
                 <View
                     android:layout_width="80dp"
                     android:layout_height="12dp"
                     android:layout_marginTop="4dp"
-                    android:background="@drawable/rounded_corner_placeholder" />
+                    android:background="@drawable/rounded_corner_placeholder_solid" />
             </LinearLayout>
         </LinearLayout>
 
@@ -50,13 +47,13 @@
             android:layout_width="match_parent"
             android:layout_height="20dp"
             android:layout_marginTop="16dp"
-            android:background="@drawable/rounded_corner_placeholder" />
+            android:background="@drawable/rounded_corner_placeholder_solid" />
 
         <View
             android:layout_width="match_parent"
             android:layout_height="200dp"
             android:layout_marginTop="8dp"
-            android:background="@drawable/rounded_corner_placeholder" />
+            android:background="@drawable/rounded_corner_placeholder_solid" />
     </LinearLayout>
 
 </com.synapse.social.studioasinc.animations.ShimmerFrameLayout>


### PR DESCRIPTION
The placeholder layout in the HomeActivity was only visible where the shimmer animation was active. This was because the placeholder views had a transparent background.

This change introduces a new drawable with a solid grey background and rounded corners. This drawable is now used as the background for the placeholder views, making them visible at all times. The shimmer animation now acts as a highlight on top of the placeholder, as intended