### PR TITLE
Debug offline notification sending

### DIFF
--- a/app/src/main/java/com/synapse/social/studioasinc/NotificationConfig.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/NotificationConfig.kt
@@ -16,7 +16,7 @@ object NotificationConfig {
     // ===== ONESIGNAL CONFIGURATION =====
     // IMPORTANT: Replace these placeholder values with your actual OneSignal credentials
     const val ONESIGNAL_APP_ID = "044e1911-6911-4871-95f9-d60003002fe2"
-    const val ONESIGNAL_REST_API_KEY = "os_v2_app_arhbseljcfehdfpz2yaagabp4jflvswe4bzekf5t4ukcruoeys27khnzzxu6gnn5waqamsfzskypitfrwcls2g2ed5e44fgcjs7pu6i"
+    const val ONESIGNAL_REST_API_KEY = "os_v2_app_arhbseljcfehdfpz2yaagabp4kjpeii7jqvuervkkbv3awuu5eubmf4nq2dgak7xeysjq5hk7s63eyoc2uylbt53d36kgoxdl5vroei"
     
     // ===== NOTIFICATION SETTINGS =====
     const val NOTIFICATION_TITLE = "New Message"

--- a/app/src/main/java/com/synapse/social/studioasinc/NotificationConfig.kt
+++ b/app/src/main/java/com/synapse/social/studioasinc/NotificationConfig.kt
@@ -50,7 +50,7 @@ object NotificationConfig {
     // ===== PRESENCE SETTINGS =====
     // Time threshold (in milliseconds) to consider a user "recently active"
     // Users who were active within this time will not receive notifications
-    const val RECENT_ACTIVITY_THRESHOLD = 5 * 60 * 1000L // 5 minutes
+    const val RECENT_ACTIVITY_THRESHOLD = 10 * 1000L // 10 seconds
     
     // ===== FEATURE FLAGS =====
     // Enable/disable smart notification suppression


### PR DESCRIPTION
Fix offline user notifications by correcting the OneSignal payload, refining suppression logic, and reducing the recent activity threshold.

Previously, notifications were suppressed if a user was merely 'online' or if the `status` field matched `chatting_with_<senderUid>`. This PR changes the suppression to only occur when the `activity` field explicitly indicates `chatting_with_<senderUid>`, ensuring notifications are delivered when a user is offline or not actively engaged in the specific chat. The `RECENT_ACTIVITY_THRESHOLD` was also reduced to ensure timely delivery after a user briefly leaves the app.

---
<a href="https://cursor.com/background-agent?bcId=bc-0cc4b149-79e1-458d-ba1a-18192f21798d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0cc4b149-79e1-458d-ba1a-18192f21798d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

